### PR TITLE
Added OnDeserializing method to AccessToken to fix the reusing of token

### DIFF
--- a/PayPalCheckoutSdk/AccessToken.cs
+++ b/PayPalCheckoutSdk/AccessToken.cs
@@ -19,13 +19,24 @@ namespace PayPalCheckoutSdk.Core
 
         public AccessToken()
         {
-            this.createDate = DateTime.Now;
+            InitializeDefaults();
         }
 
         public bool IsExpired()
         {
             DateTime expireDate = this.createDate.Add(TimeSpan.FromSeconds(this.ExpiresIn));
             return DateTime.Now.CompareTo(expireDate) > 0;
+        }
+
+        [OnDeserializing]
+        private void OnDeserializing(StreamingContext context)
+        {
+            InitializeDefaults();
+        }
+
+        private void InitializeDefaults()
+        {
+            createDate = DateTime.Now;
         }
     }
 }


### PR DESCRIPTION
Currently, the access token is not reused. It is being generated every time because createDate is not initialized via constructor of AccessToken class. It always has a default value of January 1, 0001.
Since the constructor of AccessToken class is not called during deserialisation, the OnDeserializing method was added. It allows to set the correct token creation date. Thus, IsExpired() method will return the correct value and the access token could be reused multiple times until it is expired. 